### PR TITLE
Use exec to start the main program

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,4 +8,4 @@ if [ ! -f /opt/magic_mirror/config ]; then
     cp -Rn /opt/default_config/. /opt/magic_mirror/config
 fi
 
-$1
+exec $1


### PR DESCRIPTION
When restarting the docker container, it always takes 10 seconds to restart since the SIGTERM message isn't passed to node. After 10 seconds, a SIGKILL will be send to forcefully terminate the container.

This PR uses `exec` to start the program in the init script. This helps with signal handling so a SIGTERM is passed trough to the node app. This is only one part of the fix, since currently the node app is ignoring SIGTERM messages (what it shouldn't). I will also open a fix there.

See for more information: https://hynek.me/articles/docker-signals/