### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-stretch
+FROM node:12-buster
 
 RUN apt-get update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:12-buster
 
-RUN apt-get update
-
 ENV NODE_ENV production
 WORKDIR /opt/magic_mirror
 


### PR DESCRIPTION
Switch to new stable version of Debian - `buster`

Skip updating local package database since no new packages are installed or upgraded. It only increases image size.