### PR TITLE
Config with template variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:12-buster
 
+RUN set -e; \
+    apt update; \
+    apt install -y gettext; \
+    rm -rf /var/lib/apt/lists/*
+
 ARG branch=master
 
 ENV NODE_ENV production

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Environment variables can be passed to the docker container using the `--env` fl
 If you start the container without providing a custom configuration it will create a default config inside the `config` volume if it is empty.
 This config can then be adapted to your likings.
 
+To keep passwords and API secrets out of the config file add `.template` as extension to the config file (`config.js.template`) and use shell variable syntax (`${MY_API_TOKEN}`) as placeholder for your secrets in the config file.
+Don't forget to pass the template variables as environment to the container.
+For example: `--env MY_API_TOKEN=secret-token`
+or in docker compose file:
+```yml
+    environment:
+      - MY_API_TOKEN=secret-token
+```
+
 If you want to build the configuration by yourself be sure to set the following configuration properties accordingly:
 
 ```javascript

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,4 +9,8 @@ if [ ! "$(ls -A /opt/magic_mirror/config)" ]; then
     cp /opt/magic_mirror/mm-docker-config.js /opt/magic_mirror/config/config.js
 fi
 
+if [ -f "/opt/magic_mirror/config/config.js.template" ]; then
+    envsubst < /opt/magic_mirror/config/config.js.template > /opt/magic_mirror/config/config.js
+fi
+
 exec "$@"


### PR DESCRIPTION
Add the possibility to use environment variables in the `config.js` which are evaluated once when starting the docker container. This feature only applies to `config.js.template` and generate `config.js` when the container is started. Existing configurations should not be affected by this new feature (opt-in).

The environment variables are replaced with the linux `envsubst` tool, which uses Shell variable syntax (`$name` and `${name}`) and the variables are given via the environment. `envsubst` only replaces the variables and does nothing extra such as bash substitution expressions or default values.

MichMich/MagicMirror#1947